### PR TITLE
mark Plots as required for Pendulum's plot recipe

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ Distributions
 LearnBase
 RecipesBase
 LearningStrategies 0.2.0
+Requires

--- a/src/Reinforce.jl
+++ b/src/Reinforce.jl
@@ -4,6 +4,7 @@ using Reexport
 @reexport using StatsBase
 using Distributions
 using RecipesBase
+using Requires
 
 @reexport using LearnBase
 import LearnBase: learn!, transform!, grad!, params, grad
@@ -37,6 +38,13 @@ export
   Episode,
   Episodes,
   run_episode
+
+
+# ----------------------------------------------------------------
+# Module init
+function __init__()
+  @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" include("envs/pendulum-recipe.jl")
+end
 
 
 # ----------------------------------------------------------------

--- a/src/envs/pendulum-recipe.jl
+++ b/src/envs/pendulum-recipe.jl
@@ -1,0 +1,27 @@
+@recipe function f(env::Pendulum)
+  legend := false
+  xlims := (-1,1)
+  ylims := (-1,1)
+  grid := false
+  ticks := nothing
+
+	# pole
+  @series begin
+    w = 0.2
+    x = [-w,w,w,-w]
+    y = [-.1,-.1,1,1]
+    θ = env.θs[1]
+    fillcolor := :red
+    seriestype := :shape
+    x*cos(θ) - y*sin(θ), y*cos(θ) + x*sin(θ)
+  end
+
+  # center
+  @series begin
+    seriestype := :scatter
+    markersize := 10
+    markercolor := :black
+    annotations := [(0, -0.2, Plots.text("a: $(env.a)", :top))]
+    [0],[0]
+  end
+end

--- a/src/envs/pendulum.jl
+++ b/src/envs/pendulum.jl
@@ -54,33 +54,3 @@ function state(env::Pendulum)
 end
 
 finished(env::Pendulum, s′) = env.steps >= env.maxsteps
-
-# ------------------------------------------------------------------------
-
-@recipe function f(env::Pendulum)
-  legend := false
-  xlims := (-1,1)
-  ylims := (-1,1)
-  grid := false
-  ticks := nothing
-
-	# pole
-  @series begin
-    w = 0.2
-    x = [-w,w,w,-w]
-    y = [-.1,-.1,1,1]
-    θ = env.θs[1]
-    fillcolor := :red
-    seriestype := :shape
-    x*cos(θ) - y*sin(θ), y*cos(θ) + x*sin(θ)
-  end
-
-  # center
-  @series begin
-    seriestype := :scatter
-    markersize := 10
-    markercolor := :black
-    annotations := [(0, -0.2, Plots.text("a: $(env.a)", :top))]
-    [0],[0]
-  end
-end


### PR DESCRIPTION
@raghav9-97 Could you give this branch a try?
We introduce `Requires.jl` to prevent Plots from being added as precompile dependency.

You can try this PR via
```
]add Reinforce#ib/require-plots
```