### PR TITLE
Adds module defs for cartpole and pendulum environments

### DIFF
--- a/src/envs/cartpole.jl
+++ b/src/envs/cartpole.jl
@@ -1,4 +1,4 @@
-
+module CartPoleEnv
 # Ported from: https://github.com/openai/gym/blob/996e5115621bf57b34b9b79941e629a36a709ea1/gym/envs/classic_control/cartpole.py
 # which has header:
 # 		Classic cart-pole system implemented by Rich Sutton et al.
@@ -85,4 +85,6 @@ end
     t, b = 0.0, -0.1
     [l, r, r, l], [t, t, b, b]
   end
+end
+
 end

--- a/src/envs/pendulum.jl
+++ b/src/envs/pendulum.jl
@@ -1,4 +1,4 @@
-
+module PendulumEnv
 # Ported from: https://github.com/openai/gym/blob/996e5115621bf57b34b9b79941e629a36a709ea1/gym/envs/classic_control/pendulum.py
 
 const max_speed = 8.0
@@ -83,4 +83,6 @@ finished(env::Pendulum, s′) = env.steps >= env.maxsteps
     annotations := [(0, -0.2, Plots.text("a: $(env.a)", :top))]
     [0],[0]
   end
+end
+
 end


### PR DESCRIPTION
Currently, there is no way to import the cart pole and pendulum environments like the mountain car and multi-arm bandit can be. This is a simple fix.