### PR TITLE
Pendulum: make PendulumState as subtype of AbstractArray

### DIFF
--- a/src/envs/pendulum.jl
+++ b/src/envs/pendulum.jl
@@ -22,17 +22,23 @@ const max_torque = 2.0
 
 angle_normalize(x) = ((x+π) % (2π)) - π
 
+mutable struct PendulumState{T<:Float64}  <: AbstractVector{T}
+  θ::T
+  θvel::T
+  PendulumState(θ, θvel) = Float64[θ, θvel]
+end
+
 mutable struct Pendulum <: AbstractEnvironment
-  state::Vector{Float64}
+  state::AbstractVector
   reward::Float64
   a::Float64 # last action for rendering
   steps::Int
   maxsteps::Int
 end
-Pendulum(maxsteps=500) = Pendulum([0.,0.],0.,0.,0,maxsteps)
+Pendulum(maxsteps=500) = Pendulum(PendulumState(0.,0.),0.,0.,0,maxsteps)
 
 function reset!(env::Pendulum)
-  env.state = [rand(Uniform(-π, π)), rand(Uniform(-1., 1.))]
+  env.state = PendulumState(rand(Uniform(-π, π)), rand(Uniform(-1., 1.)))
   env.reward = 0.0
   env.a = 0.0
   env.steps = 0

--- a/src/envs/pendulum.jl
+++ b/src/envs/pendulum.jl
@@ -77,7 +77,7 @@ function step!(env::Pendulum, s, a)
   newθvel = θvel + (-1.5g/l * sin(θ+π) + 3/(m*l^2)*a) * dt
   newθ = θ + newθvel * dt
   newθvel = clamp(newθvel, -max_speed, max_speed)
-  env.state = [newθ, newθvel]
+  env.state = PendulumState(newθ, newθvel)
 
   env.steps += 1
   env.reward, env.state
@@ -105,7 +105,7 @@ finished(env::Pendulum, s′) = env.steps >= env.maxsteps
     w = 0.2
     x = [-w,w,w,-w]
     y = [-.1,-.1,1,1]
-    θ = env.state[1]
+    θ = env.state.θ
     fillcolor := :red
     seriestype := :shape
     x*cos(θ) - y*sin(θ), y*cos(θ) + x*sin(θ)


### PR DESCRIPTION
- added state() to import/export
- changed state from PendulumState type to array (easier to handle in advanced algorithms)
- shortened action annotation in plot